### PR TITLE
wrong use of the boot function?

### DIFF
--- a/src/EmanueleMinotto/FakerServiceProvider.php
+++ b/src/EmanueleMinotto/FakerServiceProvider.php
@@ -16,11 +16,11 @@ class FakerServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        // ...
+        $app['faker'] = Factory::create($app['locale']);
     }
 
     public function boot(Application $app)
     {
-        $app['faker'] = Factory::create($app['locale']);
+        
     }
 }


### PR DESCRIPTION
In Silex, as it is now, the service should be registered in through register function, not the boot function
